### PR TITLE
Remove redundant repo2docker test var workaround

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -206,7 +206,6 @@ jobs:
             generate_tests_caas_test_case_slurm_enabled: false
             generate_tests_kubernetes_test_cases_latest_only: false
             generate_tests_kubernetes_apps_suite_enabled: false
-            generate_tests_caas_test_case_repo2docker_service_repo2docker_expected_title: Home
         # GitHub terminates jobs after 6 hours
         # We don't want jobs to acquire the lock then get timed out before they can finish
         # So wait a maximum of 3 hours to acquire the lock, leaving 3 hours for other tasks in the job


### PR DESCRIPTION
To be merged once https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/pull/773 is part of azimuth-config devel branch (i.e. new azimuth-ops tag > 0.14.2 is published and merged into azimuth-config).