### PR TITLE
Enable nouveau blacklisting in k8s builds

### DIFF
--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -4,5 +4,8 @@
   become: yes
   roles:
     - linux-common
+      vars:
+        blacklisted_kernel_modules:
+          - nouveau
 
 - import_playbook: ../vendor/image-builder/images/capi/ansible/node.yml

--- a/ansible/roles/linux-common/defaults/main.yml
+++ b/ansible/roles/linux-common/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+blacklisted_kernel_modules: []
 kernel_modules:
   - ib_ipoib

--- a/ansible/roles/linux-common/tasks/main.yml
+++ b/ansible/roles/linux-common/tasks/main.yml
@@ -40,6 +40,13 @@
     line: "    activators: ['networkd', 'eni', 'network-manager']"
     state: present
 
+- name: Blacklist specified kernel modules
+  community.general.kernel_blacklist:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ blacklisted_kernel_modules }}"
+  when: blacklisted_kernel_modules | length > 0
+
 - name: Clean up after ourselves
   ansible.builtin.apt:
     clean: yes


### PR DESCRIPTION
When nouveau loads on Tesla T4 (TU104), the NVIDIA driver fails to initialize properly, preventing GPU Operator pods from starting. Blacklist nouveau in linux-common to ensure the official NVIDIA driver can load without conflict.

Ref:
https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/troubleshooting.html#gpu-operator-validator-failed-to-create-pod-sandbox