### PR TITLE
CI: Change dependency update commit/PR title

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -108,11 +108,11 @@ jobs:
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
           commit-message: >-
-            Bump ${{ matrix.key }} to ${{ steps.next.outputs.version }}
+            Update ${{ matrix.key }} to ${{ steps.next.outputs.version }}
           branch: update-dependency/${{ matrix.key }}
           delete-branch: true
           title: >-
-            Bump ${{ matrix.key }} to ${{ steps.next.outputs.version }}
+            Update ${{ matrix.key }} to ${{ steps.next.outputs.version }}
           body: >
             This PR was created automatically to update
             ${{ matrix.key }} to ${{ steps.next.outputs.version }}.


### PR DESCRIPTION
Align dependency update PR and commit titles with the rest of the azimuth-cloud organisation, using "update" instead of "bump" in the message.

This might well resubmit all of the dependency-update PRs, but the inconsistency across the organisation was making my brain itch a bit.