### PR TITLE
Ignore warning about invalid jinja

### DIFF
--- a/ansible/roles/linux-webconsole/files/guacamole-playbook.yml
+++ b/ansible/roles/linux-webconsole/files/guacamole-playbook.yml
@@ -30,7 +30,7 @@
       changed_when: true
 
     - name: Set SSH keypair facts
-      ansible.builtin.set_fact:
+      ansible.builtin.set_fact: # noqa jinja[invalid]
         # yamllint disable-line rule:line-length
         guacamole_ssh_public_key: "{{ lookup('file', '/etc/guacamole/id_rsa.pub') }}"
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
ansible-lint checks for the target file when using the file lookup. This file does not exist locally because the playbook is run in the context of ansible-init on the target machine.