### PR TITLE
Pin ansible-core < 2.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core
+ansible-core<2.19
 boto3
 easysemver
 passlib


### PR DESCRIPTION
Temporarily pin to a version of ansible-core that does not detect non-boolean conditionals [1].

[1] https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html#broken-conditionals