### PR TITLE
Fix prometheus data dir ownership

### DIFF
--- a/ansible/roles/jupyter-repo2docker/tasks/main.yml
+++ b/ansible/roles/jupyter-repo2docker/tasks/main.yml
@@ -31,7 +31,7 @@
   vars:
     zenith_client_name: repo2docker-zenith-client
     zenith_client_pod: repo2docker
-    zenith_client_wants:
+    zenith_client_needs:
       - repo2docker-notebook-server
     zenith_forward_to_port: 8888
     # checkov:skip=CKV_SECRET_6

--- a/ansible/roles/linux-guacamole/tasks/main.yml
+++ b/ansible/roles/linux-guacamole/tasks/main.yml
@@ -47,7 +47,7 @@
     podman_service_image: "{{ guacamole_client_image }}"
     podman_service_pod: guacamole
     # Add a soft dependency on the server
-    podman_service_wants:
+    podman_service_needs:
       - guacamole-server
     podman_service_env:
       GUACAMOLE_HOME: /config
@@ -90,7 +90,7 @@
     podman_service_image: "{{ guacamole_nginx_image }}"
     podman_service_pod: guacamole
     # Add a soft dependency on the client
-    podman_service_wants:
+    podman_service_needs:
       - guacamole-client
     podman_service_command: >-
       nginx -c /etc/guacamole-mitm/nginx.conf

--- a/ansible/roles/linux-monitoring/tasks/grafana.yml
+++ b/ansible/roles/linux-monitoring/tasks/grafana.yml
@@ -50,7 +50,7 @@
     podman_service_name: "grafana"
     podman_service_type: container
     podman_service_pod: "monitoring"
-    podman_service_wants:
+    podman_service_needs:
       - prometheus
     podman_service_image: "{{ grafana_container_image }}"
     podman_service_volumes:

--- a/ansible/roles/linux-monitoring/tasks/main.yml
+++ b/ansible/roles/linux-monitoring/tasks/main.yml
@@ -42,7 +42,7 @@
   vars:
     zenith_client_name: monitoring-zenith-client
     zenith_client_pod: monitoring
-    zenith_client_wants:
+    zenith_client_needs:
       - grafana
     zenith_forward_to_port: "3000"
     zenith_registrar_token_metadata_key: zenith_registrar_token_monitoring

--- a/ansible/roles/linux-monitoring/tasks/prometheus.yml
+++ b/ansible/roles/linux-monitoring/tasks/prometheus.yml
@@ -21,7 +21,7 @@
     podman_service_name: "prometheus"
     podman_service_type: container
     podman_service_pod: "monitoring"
-    podman_service_wants:
+    podman_service_needs:
       - node_exporter
     podman_service_image: "{{ prometheus_container_image }}"
     podman_service_volumes:

--- a/ansible/roles/linux-podman/defaults/main.yml
+++ b/ansible/roles/linux-podman/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 podman_service_type: container
-podman_service_wants: []
+podman_service_needs: []
 podman_service_ports: []
 podman_service_env: {}
 podman_service_volumes: []

--- a/ansible/roles/linux-podman/templates/systemd.container.service.j2
+++ b/ansible/roles/linux-podman/templates/systemd.container.service.j2
@@ -8,8 +8,8 @@ BindsTo={{ podman_service_pod }}.service
 PartOf={{ podman_service_pod }}.service
 After={{ podman_service_pod }}.service
 {% endif %}
-{% for service in podman_service_wants %}
-Wants={{ service }}.service
+{% for service in podman_service_needs %}
+BindsTo={{ service }}.service
 After={{ service }}.service
 {% endfor %}
 

--- a/ansible/roles/linux-podman/templates/systemd.pod.service.j2
+++ b/ansible/roles/linux-podman/templates/systemd.pod.service.j2
@@ -3,8 +3,8 @@ Description=Podman container-{{ podman_service_name }}.service
 Documentation=man:podman-generate-systemd(1)
 Wants=network.target user@{{ podman_user_id }}.service
 After=network-online.target user@{{ podman_user_id }}.service
-{% for service in podman_service_wants %}
-Wants={{ service }}.service
+{% for service in podman_service_needs %}
+BindsTo={{ service }}.service
 After={{ service }}.service
 {% endfor %}
 

--- a/ansible/roles/linux-rdp-gateway/tasks/main.yml
+++ b/ansible/roles/linux-rdp-gateway/tasks/main.yml
@@ -43,7 +43,7 @@
   vars:
     zenith_client_name: guacamole-zenith-client
     zenith_client_pod: guacamole
-    zenith_client_wants:
+    zenith_client_needs:
       - guacamole-mitm
     zenith_forward_to_port: 8081
     zenith_registrar_token_metadata_key: zenith_registrar_token_webconsole

--- a/ansible/roles/linux-rstudio/tasks/main.yml
+++ b/ansible/roles/linux-rstudio/tasks/main.yml
@@ -48,7 +48,7 @@
   vars:
     zenith_client_name: rstudio-zenith-client
     # The deb install of rstudio-server creates a systemd unit for us
-    zenith_client_wants:
+    zenith_client_needs:
       - rstudio-server
     zenith_client_pod: rstudio
     zenith_forward_to_host: "HOST_IP"

--- a/ansible/roles/linux-user/files/user-create-playbook.yml
+++ b/ansible/roles/linux-user/files/user-create-playbook.yml
@@ -75,16 +75,6 @@
         state: mounted
       become: true
 
-    - name: Ensure Azimuth home directory has the correct permissions
-      ansible.builtin.file:
-        path: "{{ user_mountpoint }}/azimuth-home"
-        state: directory
-        owner: "azimuth"
-        group: "azimuth"
-        mode: "750"
-        recurse: true
-      become: true
-
     - name: Setup public keys for the Azimuth user
       ansible.posix.authorized_key:
         user: "azimuth"

--- a/ansible/roles/linux-user/files/user-create-playbook.yml
+++ b/ansible/roles/linux-user/files/user-create-playbook.yml
@@ -77,7 +77,7 @@
 
     - name: Ensure Azimuth home directory has the correct permissions
       ansible.builtin.file:
-        path: "{{ user_mountpoint }}"
+        path: "{{ user_mountpoint }}/azimuth-home"
         state: directory
         owner: "azimuth"
         group: "azimuth"

--- a/ansible/roles/linux-webconsole/tasks/main.yml
+++ b/ansible/roles/linux-webconsole/tasks/main.yml
@@ -113,7 +113,7 @@
   vars:
     zenith_client_name: guacamole-zenith-client
     zenith_client_pod: guacamole
-    zenith_client_wants:
+    zenith_client_needs:
       - guacamole-mitm
     zenith_forward_to_port: 8081
     zenith_registrar_token_metadata_key: zenith_registrar_token_webconsole

--- a/ansible/roles/linux-zenith-client/defaults/main.yml
+++ b/ansible/roles/linux-zenith-client/defaults/main.yml
@@ -5,7 +5,7 @@ zenith_client_image_name: zenith-client
 zenith_client_image_tag: 0.15.1
 zenith_client_image: "{{ zenith_client_image_prefix }}/{{ zenith_client_image_name }}:{{ zenith_client_image_tag }}"  # yamllint disable-line rule:line-length
 
-zenith_client_wants: []
+zenith_client_needs: []
 # The default host for forwarding is the pod that the client is in
 zenith_forward_to_host: 127.0.0.1
 

--- a/ansible/roles/linux-zenith-client/tasks/main.yml
+++ b/ansible/roles/linux-zenith-client/tasks/main.yml
@@ -32,7 +32,7 @@
     podman_service_name: "{{ zenith_client_name }}"
     podman_service_type: container
     podman_service_pod: "{{ zenith_client_pod }}"
-    podman_service_wants: "{{ zenith_client_wants }}"
+    podman_service_needs: "{{ zenith_client_needs }}"
     podman_service_image: "{{ zenith_client_image }}"
     podman_service_command: "zenith-client connect"
     podman_service_volumes:


### PR DESCRIPTION
Fixes an issue where ansible-init recursively changes permissions on the entire `/data` directory while setting up the `azimuth` user account when it instead should only be changing permissions on `/data/azimuth-home`.