### PR TITLE
Allow substitution of Swift prefix for public image urls

### DIFF
--- a/.github/workflows/build_test_images.yaml
+++ b/.github/workflows/build_test_images.yaml
@@ -81,6 +81,7 @@ jobs:
           IMAGE_SOURCE_FILE: ${{ steps.build-image.outputs.image-source-file }}
           # Upload images to a fixed S3 host
           S3_HOST: ${{ vars.S3_HOST }}
+          S3_HOST_PUBLIC_PATH: ${{ vars.S3_HOST_PUBLIC_PATH }}
           S3_BUCKET: ${{ vars.S3_BUCKET }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/bin/publish-image
+++ b/bin/publish-image
@@ -40,8 +40,8 @@ s3cmd put "${IMAGE_NAME}.cosign.bundle" "s3://$S3_BUCKET"
 # COSIGN_BUNDLE_URL="$(s3cmd signurl "s3://$S3_BUCKET/${IMAGE_NAME}.cosign.bundle" +31536000)"
 
 # Use public Swift URL instead of signed link
-IMAGE_URL="https://${S3_HOST}/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/${S3_BUCKET}/${IMAGE_NAME}.qcow2"
-COSIGN_BUNDLE_URL="https://${S3_HOST}/swift/v1/AUTH_f0dc9cb312144d0aa44037c9149d2513/${S3_BUCKET}/${IMAGE_NAME}.cosign.bundle"
+IMAGE_URL="https://${S3_HOST}${S3_HOST_PUBLIC_PATH}/${S3_BUCKET}/${IMAGE_NAME}.qcow2"
+COSIGN_BUNDLE_URL="https://${S3_HOST}${S3_HOST_PUBLIC_PATH}/${S3_BUCKET}/${IMAGE_NAME}.cosign.bundle"
 
 # Get the checksum of the image
 IMAGE_CHECKSUM="sha256:$(sha256sum "${IMAGE_NAME}.qcow2" | awk '{ print $1 }')"


### PR DESCRIPTION
Making this a variable allows us to specify it in repository variables to enable switching of S3 provider without changing code.

GH repository variables are an empty string if they are undefined, so the URLs are still valid even if  `vars.S3_HOST_PUBLIC_PATH` is not defined.